### PR TITLE
Fix infinite loop on _dot

### DIFF
--- a/jquery.thecalculator.js
+++ b/jquery.thecalculator.js
@@ -191,6 +191,8 @@
 
             if(!x) {
                 this.currentDisplay.push('0');
+                this.currentDisplay.push('.');
+                return false;
             }
 
             while( --x) {


### PR DESCRIPTION
When you pressed the dot button before a zero it created an infinite
loop, this repairs that problem.
